### PR TITLE
Slow down other end of the Derogam gateway

### DIFF
--- a/data/map.txt
+++ b/data/map.txt
@@ -796,6 +796,7 @@ system Arotina
 			period 262.514
 	object Derogate
 		sprite planet/derogamgate
+			"frame rate" 0.25
 		distance 8369.965
 		period 3877.76
 	object


### PR DESCRIPTION
One end was slow as intended, one was 4 times as fast as was default. This just slows them both down to the intended speed.